### PR TITLE
Fix for different root names of openhab event tree (Openhab 3.0.0 M5)

### DIFF
--- a/nodes/openhab-v2-controller.js
+++ b/nodes/openhab-v2-controller.js
@@ -142,9 +142,10 @@ module.exports = function(RED) {
         }
 
         // Topic e.g. 'smarthome/items/My_Light_Switch/state'
-        // This grabs the string between the first 16 characters and the last '/' which is the item name
+        // Topic e.g. 'openhab/items/My_Light_Switch/state'
+        // This grabs the string between the first '/' + 6 characters and the last '/' which is the item name
         // In case of a GroupItemStateChangedEvent the item will have multiple segments e.g. GroupItemName/MemberItemName
-        const [item] = parsedMessage.topic.slice(16, parsedMessage.topic.lastIndexOf('/')).split('/');
+        const [item] = parsedMessage.topic.slice(parsedMessage.topic.indexOf('/') + 7, parsedMessage.topic.lastIndexOf('/')).split('/');
         const type = parsedMessage.type;
         const state = parsedMessage.payload.value;
         const payload = parsedMessage.payload;


### PR DESCRIPTION
When looking into the event-stream, I noticed that my root directory/string for events wasn't 'smarthome', but 'openhab' instead. This is probably by my own doing during the setup of my installation (which I don't really recall). But since 'smarthome' isn't the only viable root string I had to apply a fix in the controller code.

I'm running on Openhab 3.0.0 M5